### PR TITLE
Fix for mis-positioned live cursors 2: this time it’s personal

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,6 +17,7 @@
 	body {
 		padding: 0;
 		color: black;
+		position: relative;
 	}
 	
 	body.dark {
@@ -50,7 +51,6 @@
 		min-height: 100vh;
 		display: flex;
 		flex-direction: column;
-		position: relative;
 	}
 	
 	main {

--- a/src/components/CursorsDisplay.vue
+++ b/src/components/CursorsDisplay.vue
@@ -1,5 +1,5 @@
 <template>
-	<teleport to="#app">
+	<teleport to="body">
 		<div v-if="optOutStatus===false && mobile === false" class="cursorsBox">
 			<cursor-display :self="true" :player="player" />
 			<cursor-display 


### PR DESCRIPTION
Had to use the nuclear option: moving the cursor container outside the app entirely.