### PR TITLE
Fix for bad fonts on cursors.

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -18,6 +18,7 @@
 		padding: 0;
 		color: black;
 		position: relative;
+		font-family: Epilogue, Avenir, Helvetica, Arial, sans-serif;
 	}
 	
 	body.dark {


### PR DESCRIPTION
Cursor labels weren’t set in Epilog because they had been moved outside of the #app. This has been fixed.